### PR TITLE
Use htaccess for redirects instead of jekyll plugin

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,56 @@
+# custom error pages
+
 ErrorDocument 404 /404.html
+
+# custom redirects for old blog URLs
+
+Redirect 301 /built-with-open-source/ /blog/built-with-open-source/
+Redirect 301 /apples-to-apples/ /blog/apples-to-apples/
+Redirect 301 /status-bars-matter/ /blog/status-bars-matter/
+Redirect 301 /apples-to-apples-part-two/ /blog/apples-to-apples-part-two/
+Redirect 301 /on-the-value-of-benchmarks/ /blog/on-the-value-of-benchmarks/
+Redirect 301 /apples-to-apples-part-three/ /blog/apples-to-apples-part-three/
+Redirect 301 /adaptive-user-interfaces/ /blog/adaptive-user-interfaces/
+Redirect 301 /swift-failable-initializers/ /blog/swift-failable-initializers/
+Redirect 301 /rosetta-stone-contributes/ /blog/rosetta-stone-contributes/
+Redirect 301 /introducing-jsqmessagesvc-6-0/ /blog/introducing-jsqmessagesvc-6-0/
+Redirect 301 /swift-coredata-and-testing/ /blog/swift-coredata-and-testing/
+Redirect 301 /better-coredata-models-in-swift/ /blog/better-coredata-models-in-swift/
+Redirect 301 /functional-notifications/ /blog/functional-notifications/
+Redirect 301 /swift-failable-initializers-revisited/ /blog/swift-failable-initializers-revisited/
+Redirect 301 /using-core-data-in-swift/ /blog/using-core-data-in-swift/
+Redirect 301 /swift-namespaced-constants/ /blog/swift-namespaced-constants/
+Redirect 301 /swift-enumerations-and-equatable/ /blog/swift-enumerations-and-equatable/
+Redirect 301 /UIKit-changes-in-iOS-9/ /blog/UIKit-changes-in-iOS-9/
+Redirect 301 /building-data-sources-in-swift/ /blog/building-data-sources-in-swift/
+Redirect 301 /swift-open-source/ /blog/swift-open-source/
+Redirect 301 /open-source-swift-weekly-1/ /blog/open-source-swift-weekly-1/
+Redirect 301 /open-source-swift-weekly-2/ /blog/open-source-swift-weekly-2/
+Redirect 301 /open-source-swift-weekly-3/ /blog/open-source-swift-weekly-3/
+Redirect 301 /open-source-swift-weekly-4/ /blog/open-source-swift-weekly-4/
+Redirect 301 /new-weekly-brief/ /blog/new-weekly-brief/
+Redirect 301 /jsqmessages-call-for-contributors/ /blog/jsqmessages-call-for-contributors/
+Redirect 301 /swifty-presenters/ /blog/swifty-presenters/
+Redirect 301 /contributing-to-swift/ /blog/contributing-to-swift/
+Redirect 301 /swift-documentation/ /blog/swift-documentation/
+Redirect 301 /open-source-everything/ /blog/open-source-everything/
+Redirect 301 /avoiding-objc-in-swift/ /blog/avoiding-objc-in-swift/
+Redirect 301 /the-a5-is-dead/ /blog/the-a5-is-dead/
+Redirect 301 /swift-3-sherlocked-my-libraries/ /blog/swift-3-sherlocked-my-libraries/
+Redirect 301 /migrating-to-swift-3/ /blog/migrating-to-swift-3/
+Redirect 301 /enums-as-configs/ /blog/enums-as-configs/
+Redirect 301 /speaking-at-frenchkit/ /blog/speaking-at-frenchkit/
+Redirect 301 /shipping-swift-3/ /blog/shipping-swift-3/
+Redirect 301 /understanding-swift-evolution/ /blog/understanding-swift-evolution/
+Redirect 301 /contributing-to-swift-weekly/ /blog/contributing-to-swift-weekly/
+Redirect 301 /140-proposals-frenchkit-video/ /blog/140-proposals-frenchkit-video/
+Redirect 301 /swift-documentation-part-2/ /blog/swift-documentation-part-2/
+Redirect 301 /testing-without-ocmock/ /blog/testing-without-ocmock/
+Redirect 301 /pushing-limits-of-pop/ /blog/pushing-limits-of-pop/
+Redirect 301 /prioritization/ /blog/prioritization/
+Redirect 301 /sleazy-recruiting/ /blog/sleazy-recruiting/
+Redirect 301 /refactoring-singletons-in-swift/ /blog/refactoring-singletons-in-swift/
+Redirect 301 /adapting-to-change-and-cutting-corners/ /blog/adapting-to-change-and-cutting-corners/
+Redirect 301 /swift-unwrapped/ /blog/swift-unwrapped/
+Redirect 301 /thoughts-on-swift-access-control/ /blog/thoughts-on-swift-access-control/
+Redirect 301 /a-fair-hotel/ /blog/a-fair-hotel/

--- a/_config.yml
+++ b/_config.yml
@@ -2,14 +2,13 @@
 markdown: kramdown
 
 kramdown:
-   input: GFM
-   syntax_highlighter: rouge
+    input: GFM
+    syntax_highlighter: rouge
 
 gems:
-  - jekyll-paginate
-  - jekyll-seo-tag
-  - jekyll-sitemap
-  - jekyll-redirect-from
+    - jekyll-paginate
+    - jekyll-seo-tag
+    - jekyll-sitemap
 
 exclude: [vendor, Dangerfile, Gemfile, Gemfile.lock, LICENSE, README.md, bower.json, scripts/]
 include: [.htaccess]
@@ -27,14 +26,14 @@ logo: /img/logo.png
 timezone: America/Los_Angeles
 
 twitter:
-  username: jesse_squires
+    username: jesse_squires
 
 img_url: /img
 
 # Author
 author:
-  name: 'Jesse Squires'
-  twitter: jesse_squires
+    name: 'Jesse Squires'
+    twitter: jesse_squires
 
 # Setup
 paginate: 4
@@ -42,15 +41,15 @@ excerpt_separator: <!--excerpt-->
 
 # Data
 links:
-  github: 'https://github.com/jessesquires/jessesquires.com'
-  issue: 'https://github.com/jessesquires/jessesquires.com/issues/new'
-  pull: 'https://github.com/jessesquires/jessesquires.com/compare'
+    github: 'https://github.com/jessesquires/jessesquires.com'
+    issue: 'https://github.com/jessesquires/jessesquires.com/issues/new'
+    pull: 'https://github.com/jessesquires/jessesquires.com/compare'
 
 social_links:
-  twitter: 'https://twitter.com/jesse_squires'
-  github: 'https://github.com/jessesquires/'
-  linkedin: 'https://www.linkedin.com/in/jessesquires'
-  applenews: 'https://apple.news/Td_gVU2BDSS2oPbz_sD150w'
-  paypal: 'https://www.paypal.me/jessesquires'
-  square: 'https://cash.me/$jsq'
-  coinbase: 'https://www.coinbase.com/jsq'
+    twitter: 'https://twitter.com/jesse_squires'
+    github: 'https://github.com/jessesquires/'
+    linkedin: 'https://www.linkedin.com/in/jessesquires'
+    applenews: 'https://apple.news/Td_gVU2BDSS2oPbz_sD150w'
+    paypal: 'https://www.paypal.me/jessesquires'
+    square: 'https://cash.me/$jsq'
+    coinbase: 'https://www.coinbase.com/jsq'

--- a/_posts/2014-06-09-built-with-open-source.md
+++ b/_posts/2014-06-09-built-with-open-source.md
@@ -2,7 +2,6 @@
 layout: post
 title: Built with open-source
 subtitle: The beginnings of this blog
-redirect_from: /built-with-open-source/
 ---
 
 XKCD's posts on [saving time](http://xkcd.com/1205/) and [automation](http://xkcd.com/1319/) are precisely how this blog came to be. Until now, I never had the time or motivation to write on a regular basis, though I considered it often. I've been developing for iOS for a few years now and I've become increasingly involved in the Objective-C open-source community via [GitHub](https://github.com/jessesquires) and [CocoaPods](http://cocoapods.org), and was lucky enough to attend (*my first!*) [WWDC](https://developer.apple.com/wwdc) this year on its 25th anniversary. It was an awesome experience. With that said, I can't think of a better time or better reason to begin writing about my experiences with iOS and Objective-C (and now [Swift](https://developer.apple.com/swift/)), as well as my involvement in open-source. I hope to share worthwhile and interesting things here.
@@ -20,11 +19,11 @@ This site is lovingly powered by [Jekyll](http://jekyllrb.com), [Bootstrap](http
 This world would be significantly different without the concept of [open-source](http://en.wikipedia.org/wiki/Open_source), which is an idea that has been around for millenia. Though it was not always referred to as "open-source", the core ideas persist. Only through the processes of sharing, [collaboration](http://blogs.sciencemag.org/origins/2009/09/on-the-origin-of-cooperation.html), and [reciprocity](http://www.sciencedaily.com/releases/2013/08/130820094643.htm) did our ancestors establish a stable, thriving society. It is this kind of openness and cooperation that has fostered our thriving community of programmers. Whether or not we can describe it as [*stable*](http://heartbleed.com), I'll leave up to you. Nearly all of the software in-use today was built on, supported by, or influenced by [**open-source software**](http://en.wikipedia.org/wiki/Open-source_software). It would be naive to think that the different technologies and apps that we take for granted every single day would be here without that help.
 
 <blockquote>
-	<p>If I have seen further it is by standing on the shoulders of giants.</p>
-	<footer>
-		<a href="http://en.wikiquote.org/wiki/Isaac_Newton" target="_blank">Isaac Newton</a>
-		(or <a href="http://en.wikipedia.org/wiki/Bernard_of_Chartres" target="_blank">Bernard of Chartres</a>, if you're hip with French philosophers)
-	</footer>
+    <p>If I have seen further it is by standing on the shoulders of giants.</p>
+    <footer>
+        <a href="http://en.wikiquote.org/wiki/Isaac_Newton" target="_blank">Isaac Newton</a>
+        (or <a href="http://en.wikipedia.org/wiki/Bernard_of_Chartres" target="_blank">Bernard of Chartres</a>, if you're hip with French philosophers)
+    </footer>
 </blockquote>
 
 **Future posts will focus on iOS, Cocoa, Objective-C, Swift, and open-source.**

--- a/_posts/2014-06-25-apples-to-apples.md
+++ b/_posts/2014-06-25-apples-to-apples.md
@@ -3,7 +3,6 @@ layout: post
 title: Apples to apples
 date-updated: 1 Aug 2014
 subtitle: A comparison of sorts between Objective-C and Swift
-redirect_from: /apples-to-apples/
 ---
 
 When Craig Federighi arrived at his presentation slide about Objective-C during this year's [WWDC keynote](http://www.apple.com/apple-events/june-2014/) everyone in the room seemed puzzled, curious, and maybe even a bit uneasy. *What was happening?* As he continued, he considered what Objective-C would be like **without the C**, and the room abruptly filled with rumblings and whispers <sup><a href="#note1" id="superscript1">[1]</a></sup> as developers in the audience confided in those around them. If you had been following the [discussions](http://informalprotocol.com/2014/02/replacing-cocoa/) in our community about the [state of Objective-C](http://nearthespeedoflight.com/article/2014_03_17_objective_next) (and why we [need to replace it](http://ashfurrow.com/blog/we-need-to-replace-objective-c)) during the previous months, you could only have imagined one thing: Objective-C was no more &mdash; at least not as we knew it.

--- a/_posts/2014-08-03-status-bars-matter.md
+++ b/_posts/2014-08-03-status-bars-matter.md
@@ -3,7 +3,6 @@ layout: post
 title: Status bars matter
 date-updated: 13 Oct 2014
 subtitle: Perfecting your app screenshots for the App Store
-redirect_from: /status-bars-matter/
 ---
 
 You have spent countless hours, days, months, or maybe even [years](http://www.polygon.com/2014/2/6/5386200/why-it-took-a-year-to-make-and-then-break-down-an-amazing-puzzle-game) perfecting your app. There has been plenty of blood, sweat, and tears. Your relationships and your health have [suffered through](http://blog.jaredsinclair.com/post/93118460565/a-candid-look-at-unreads-first-year) the development process. You are ready for 1.0 and the time has arrived to prepare all of your content for the App Store &mdash; app icon, keywords, description, localizations, and screenshots (and soon [app previews](https://developer.apple.com/support/appstore/app-previews/)).

--- a/_posts/2014-08-06-apples-to-apples-part-two.md
+++ b/_posts/2014-08-06-apples-to-apples-part-two.md
@@ -2,7 +2,6 @@
 layout: post
 title: Apples to apples, Part II
 subtitle: An analysis of sorts between Objective-C and Swift
-redirect_from: /apples-to-apples-part-two/
 ---
 
 If at first you don't succeed, try, try again. Practice makes perfect. These proverbs have encouraged us all in many different contexts. But in software development, they tug at our heartstrings uniquely. Programmers persevere through countless nights of fixing bugs. Companies march vigilantly toward an [MVP](http://en.wikipedia.org/wiki/Minimum_viable_product). But after 1.0 there is no finish line, there is no bottom of the 9th inning. There are more bugs to be fixed. There are new releases ahead. The march continues, because software is not a *product*, it is a *process*.

--- a/_posts/2014-08-19-on-the-value-of-benchmarks.md
+++ b/_posts/2014-08-19-on-the-value-of-benchmarks.md
@@ -2,7 +2,6 @@
 layout: post
 title: On the value of benchmarks
 subtitle: A brief examination of measuring code performance
-redirect_from: /on-the-value-of-benchmarks/
 ---
 
 As [*Apples to apples, Part II*](/apples-to-apples-part-two/) made its way around the web, it was [praised](https://twitter.com/SwiftLang/status/497057489766981632) as well as [critiqued](https://twitter.com/benpickering/status/497127012814041088). The latter largely consisted of questions regarding the real-world applications of these benchmarks. In general, benchmarks should be taken with a grain of salt. I want to take a minute to clarify my thoughts on benchmarks and how I think they can be valuable.

--- a/_posts/2014-08-21-apples-to-apples-part-three.md
+++ b/_posts/2014-08-21-apples-to-apples-part-three.md
@@ -2,7 +2,6 @@
 layout: post
 title: Apples to apples, Part III
 subtitle: A modest proposal&#58; can Swift outperform plain C?
-redirect_from: /apples-to-apples-part-three/
 ---
 
 *When I find my code is slow or troubled, friends and colleagues comfort me. Speaking words of wisdom, write in C.* It is understood that foregoing the features and abstractions of [high-level](http://en.wikipedia.org/wiki/High-level_programming_language) programming languages in favor of their [low-level](http://en.wikipedia.org/wiki/Low-level_programming_language) counterparts can yield faster, more efficient code. If you abandon your favorite runtime, forget about garbage collection, eschew dynamic typing, and leave message passing behind; then you will be left with scalar operations, manual memory management, and raw pointers. However, the closer we get to the hardware, the further we get from readability, safety, and maintainability.

--- a/_posts/2014-10-01-adaptive-user-interfaces.md
+++ b/_posts/2014-10-01-adaptive-user-interfaces.md
@@ -2,7 +2,6 @@
 layout: post
 title: Adaptive user interfaces
 subtitle: Exploring iOS size classes and trait collections
-redirect_from: /adaptive-user-interfaces/
 ---
 
 When the App Store launched, there was one iPhone with one screen size and one pixel density. Designing your user interfaces was relatively simple and the [technical debt](http://martinfowler.com/bliki/TechnicalDebt.html) of hard-coding them was cheap. Today, developers and designers face many challenges in creating apps that must work on dozens of different devices. [Long gone](https://www.apple.com/iphone/compare/) are the days of 480x320. We can no longer depend on physical screen sizes and must always be prepared for the next generation of devices.

--- a/_posts/2014-10-22-swift-failable-initializers.md
+++ b/_posts/2014-10-22-swift-failable-initializers.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swift failable initializers
 subtitle: When failable becomes fallible, and how to avoid it
-redirect_from: /swift-failable-initializers/
 ---
 
 Swift is still young and ever-changing. With each release, we have seen dozens of tweaks, additions, and deletions. And there is no reason for us to think that this rapid evolution will decline anytime soon. To remind us of exactly that, the latest [post](https://developer.apple.com/swift/blog/?id=17) on Apple's [Swift Developer Blog](https://developer.apple.com/swift/) introduces a new feature in Swift 1.1 in [Xcode 6.1](https://developer.apple.com/xcode/downloads/) &mdash; *failable initializers*.

--- a/_posts/2014-12-05-rosetta-stone-contributes.md
+++ b/_posts/2014-12-05-rosetta-stone-contributes.md
@@ -2,7 +2,6 @@
 layout: post
 title: Rosetta Stone contributes
 subtitle: Rosetta Stone officially joins the open-source community
-redirect_from: /rosetta-stone-contributes/
 ---
 
 I'm incredibly happy and incredibly proud to share that [Rosetta Stone](http://www.rosettastone.com) is an [open-source software](http://en.wikipedia.org/wiki/Open-source_software) contributor. Since I started working at Rosetta Stone a little more than a year ago, I've been encouraging and advocating for the company to get involved in open-source. Today, we did just that. Today is a big day for Rosetta Stone.

--- a/_posts/2014-12-08-introducing-jsqmessagesvc-6-0.md
+++ b/_posts/2014-12-08-introducing-jsqmessagesvc-6-0.md
@@ -2,7 +2,6 @@
 layout: post
 title: Introducing JSQMessagesVC 6.0
 subtitle: A brief history and celebration of the popular messages UI library for iOS
-redirect_from: /introducing-jsqmessagesvc-6-0/
 ---
 
 A few weeks ago I published the [sixth major release](https://github.com/jessesquires/JSQMessagesViewController/releases/tag/6.0.0) of ~~my~~ *our* [messages UI library](http://www.jessesquires.com/JSQMessagesViewController/) for iOS. This release closes the door on a major milestone for this project, so I wanted to take the time to highlight its significance, discuss its new features, and examine its design. Of course, this would not have been possible without our amazing open-source [community](https://github.com) and the [contributors](https://github.com/jessesquires/JSQMessagesViewController/graphs/contributors) to this project.

--- a/_posts/2015-01-05-swift-coredata-and-testing.md
+++ b/_posts/2015-01-05-swift-coredata-and-testing.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swift, Core Data, and unit testing
 subtitle: Working around Swift's constraints to unit test models
-redirect_from: /swift-coredata-and-testing/
 ---
 
 [Core Data](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/CoreData/cdProgrammingGuide.html) is probably loved as much as it is shunned by iOS developers. It is a framework of great power that often comes with great frustration. But it remains a popular tool among developers despite its pitfalls &mdash; likely because Apple continues to [invest](https://developer.apple.com/videos/wwdc/2014/?id=225) in it and encourages its adoption, as well as the availability of the [many](http://nshipster.com/core-data-libraries-and-utilities/) open-source [libraries](https://github.com/rosettastone/RSTCoreDataKit) that make Core Data easier to use. Consider unit testing, and Core Data gets a bit more cumbersome. Luckily, there are [established techniques](https://github.com/rosettastone/RSTCoreDataKit#unit-testing) to facilitate testing your models. Add [Swift](http://www.apple.com/swift/) to this equation, and the learning curve gets slightly steeper.

--- a/_posts/2015-02-17-better-coredata-models-in-swift.md
+++ b/_posts/2015-02-17-better-coredata-models-in-swift.md
@@ -2,7 +2,6 @@
 layout: post
 title: Better Core Data models in Swift
 subtitle: How Swift can bring clarity and safety to your managed objects
-redirect_from: /better-coredata-models-in-swift/
 ---
 
 As I continue my work with [Core Data](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/CoreData/cdProgrammingGuide.html) and [Swift](http://www.apple.com/swift/), I have been trying to find ways to make Core Data **better**. Among my goals are clarity and safety, specifically regarding types. Luckily, we can harness Swift's optionals, enums, and other features to make managed objects more robust and more clear. But even with the improvements that Swift brings, there are still some drawbacks and limitations with Xcode's current toolset.

--- a/_posts/2015-03-31-functional-notifications.md
+++ b/_posts/2015-03-31-functional-notifications.md
@@ -2,7 +2,6 @@
 layout: post
 title: Functional notifications
 subtitle: Exploring the flexibility of Swift micro-libraries
-redirect_from: /functional-notifications/
 ---
 
 The [observer pattern](http://en.wikipedia.org/wiki/Observer_pattern) is a powerful way to decouple the sending and handling of events between objects in a system. On iOS, one implementation of this pattern is via [NSNotificationCenter](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSNotificationCenter_Class). However, the `NSNotificationCenter` APIs are kind of cumbersome to use and require some boilerplate code. Luckily, Swift gives us the tools to improve `NSNotificationCenter` with very little code.

--- a/_posts/2015-04-06-swift-failable-initializers-revisited.md
+++ b/_posts/2015-04-06-swift-failable-initializers-revisited.md
@@ -2,7 +2,6 @@
 layout: post
 title: Failable initializers, revisited
 subtitle: Functional approaches to avoid Swift's failable initializers
-redirect_from: /swift-failable-initializers-revisited/
 ---
 
 In a [previous](/swift-failable-initializers/) post, I discussed how Swift's [failable initializers](https://developer.apple.com/swift/blog/?id=17) could be problematic. Specifically, I argued that their ease of use could persuade or encourage us to revert to old (bad) Objective-C habits of returning `nil` from `init`. Initialization is usually *not the right place* to fail. We should aim to avoid optionals as much as possible to reduce having to handle this absence of values. Recently, **@danielgomezrico** asked a great [question](https://github.com/jessesquires/jessesquires.github.io/issues/8) about a possible use case for a failable initializer &mdash; parsing JSON. [Given](http://owensd.io/2014/06/18/json-parsing.html) [this](http://chris.eidhof.nl/posts/json-parsing-in-swift.html) problem's [popularity](https://github.com/SwiftyJSON/SwiftyJSON) in the Swift community, I thought sharing my response here would be helpful.

--- a/_posts/2015-05-25-using-core-data-in-swift.md
+++ b/_posts/2015-05-25-using-core-data-in-swift.md
@@ -2,7 +2,6 @@
 layout: post
 title: Using Core Data in Swift
 subtitle: Talk at Realm in San Francisco
-redirect_from: /using-core-data-in-swift/
 ---
 
 I recently gave a talk at the Swift Language User Group ([#SLUG](http://www.meetup.com/swift-language/events/220612410/)) meetup at [Realm](http://realm.io) in San Francisco. A [video of the talk](http://realm.io/news/jesse-squires-core-data-swift/) is now online over at Realm's blog, where it is synced up with my [slides](https://speakerdeck.com/jessesquires/using-core-data-in-swift). If you haven't already seen it, go check it out! Realm does an absolutely amazing job with posting these meetup talks &mdash; in addition to the video and slides, there's a full transcript and subtitles.

--- a/_posts/2015-07-19-swift-namespaced-constants.md
+++ b/_posts/2015-07-19-swift-namespaced-constants.md
@@ -3,7 +3,6 @@ layout: post
 title: Namespaced constants in Swift
 subtitle: Using nested types for clarity
 date-updated: 23 July 2015
-redirect_from: /swift-namespaced-constants/
 ---
 
 Mike Ash has a great [Friday Q&A](https://www.mikeash.com/pyblog/friday-qa-2011-08-19-namespaced-constants-and-functions.html) on namespaced constants and functions in C. It is a powerful and elegant technique to avoid using `#define` and verbose Objective-C prefixes. Although Swift types are namespaced by their module, we can still benefit from implementing this pattern with `struct` and `enum` types. I've been experimenting with this approach for constants in Swift and it has been incredibly useful.

--- a/_posts/2015-07-26-swift-enumerations-and-equatable.md
+++ b/_posts/2015-07-26-swift-enumerations-and-equatable.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swift enumerations and equatable
 subtitle: Implementing equatable for enums with associated values
-redirect_from: /swift-enumerations-and-equatable/
 ---
 
 Recently, I came across a **case** (*pun intended*) where I needed to compare two instances of an `enum` type in Swift. However, it was an `enum` where some cases had [associated values](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Enumerations.html#//apple_ref/doc/uid/TP40014097-CH12-ID148). At first glance, it is not obvious how to do this.

--- a/_posts/2015-10-14-UIKit-changes-in-iOS-9.md
+++ b/_posts/2015-10-14-UIKit-changes-in-iOS-9.md
@@ -2,7 +2,6 @@
 layout: post
 title: UIKit changes in iOS 9
 subtitle: Goodbye non-zeroing weak references
-redirect_from: /UIKit-changes-in-iOS-9/
 ---
 
 Surprisingly, I have not seen anyone talking about what I just discovered in the [iOS 9.0 API Diffs](https://developer.apple.com/library/prerelease/ios/releasenotes/General/iOS90APIDiffs/index.html#//apple_ref/doc/uid/TP40016222). (Well, actually what [Max von Webel](https://twitter.com/343max/status/654513094559817728) discovered.) There's a hidden gem in the [UIKit diffs](https://developer.apple.com/library/prerelease/ios/releasenotes/General/iOS90APIDiffs/Objective-C/UIKit.html). We no longer have to suffer through tracking down obscure bugs due to non-zeroing weak references.

--- a/_posts/2015-10-25-building-data-sources-in-swift.md
+++ b/_posts/2015-10-25-building-data-sources-in-swift.md
@@ -2,7 +2,6 @@
 layout: post
 title: Building type-safe, composable data sources in Swift
 subtitle: A modern approach to collection views and table views
-redirect_from: /building-data-sources-in-swift/
 ---
 
 In iOS development, the core of nearly every app rests on the foundations provided by `UICollectionView` and `UITableView`. These APIs make it simple to build interfaces that display the data in our app, and allow us to easily interact with those data. Because they are so frequently used, it makes sense to optimize and refine how we use them &mdash; to reduce the boilerplate involved in setting them up, to make them testable, and more. With Swift, we have new ways with which we can approach these APIs and reimagine how we use them to build apps.

--- a/_posts/2015-12-06-swift-open-source.md
+++ b/_posts/2015-12-06-swift-open-source.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swift open source
 subtitle: Let the revolution begin
-redirect_from: /swift-open-source/
 ---
 
 It has only been a few days since the announcement of [Swift going open source](https://developer.apple.com/swift/blog/?id=34) and the activity around the project has been incredible. When Apple revealed that Swift would be open source at [WWDC](https://developer.apple.com/wwdc/) earlier this year, I do not think anyone anticipated a release like this.

--- a/_posts/2015-12-10-open-source-swift-weekly-1.md
+++ b/_posts/2015-12-10-open-source-swift-weekly-1.md
@@ -2,7 +2,6 @@
 layout: post
 title: "Open source Swift&#58; weekly brief"
 subtitle: What's been happening during the first full week on Swift.org?
-redirect_from: /open-source-swift-weekly-1/
 ---
 
 It looks many developers in the community enjoyed my [previous post](http://www.jessesquires.com/swift-open-source/) detailing my thoughts and observations on the activity around the [Swift open source project](https://swift.org). So, I'm going to try to do this weekly &mdash; every Thursday, since the open source announcement was on a Thursday. Each week I'll provide a high-level summary of what's been happening, updates on interesting statistics, and links to interesting content. If you have any suggestions, please [let me know](https://twitter.com/jesse_squires)! And now, the weekly brief!

--- a/_posts/2015-12-17-open-source-swift-weekly-2.md
+++ b/_posts/2015-12-17-open-source-swift-weekly-2.md
@@ -2,7 +2,6 @@
 layout: post
 title: "Open source Swift&#58; weekly brief #2"
 subtitle: What's been happening on Swift.org?
-redirect_from: /open-source-swift-weekly-2/
 ---
 
 The Swift.org community is finishing up its second full week of open source development. If you were hoping for a quiet week, you will definitely be disappointed. There is still a ton of activity with no signs of slowing down. The Swift team [continues](https://twitter.com/uint_min/status/675022507527684096) to work openly and to be [encouraging](https://github.com/apple/swift/pull/389#issuecomment-163851653) to contributors. This week brought more crash fixes and more Swift Evolution proposals. Let's get to it &mdash; the weekly brief!

--- a/_posts/2015-12-24-open-source-swift-weekly-3.md
+++ b/_posts/2015-12-24-open-source-swift-weekly-3.md
@@ -2,7 +2,6 @@
 layout: post
 title: "Open source Swift&#58; weekly brief #3"
 subtitle: What's been happening on Swift.org?
-redirect_from: /open-source-swift-weekly-3/
 ---
 
 As expected with the holiday season, [things are](https://lists.swift.org/pipermail/swift-corelibs-dev/Week-of-Mon-20151214/000179.html) [slowing down](https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151221/000540.html) for a bit on Swift.org. I have been traveling for the holidays as well, so this issue will be shorter than usual. If you haven't already, be sure you take some time away from coding to enjoy the holidays and [avoid burnout](https://twitter.com/chriseidhof/status/679213894343200768). 😄 Now, the weekly brief!

--- a/_posts/2016-01-07-open-source-swift-weekly-4.md
+++ b/_posts/2016-01-07-open-source-swift-weekly-4.md
@@ -2,7 +2,6 @@
 layout: post
 title: "Open source Swift&#58; weekly brief #4"
 subtitle: What's been happening on Swift.org?
-redirect_from: /open-source-swift-weekly-4/
 ---
 
 Now that the holidays are over, things have started to pick up again on Swift.org. If you are following any of the repos on GitHub, you have probably noticed. I'm not sure how I missed this before, but this week I just discovered [SwiftExperimental.swift](https://github.com/apple/swift/blob/master/stdlib/internal/SwiftExperimental/SwiftExperimental.swift). For now, it defines a bunch of custom unicode operators for `Set`. It's really cool. I would love to see more APIs like this in the standard library. Anyway, here's the weekly brief!

--- a/_posts/2016-01-14-new-weekly-brief.md
+++ b/_posts/2016-01-14-new-weekly-brief.md
@@ -2,7 +2,6 @@
 layout: post
 title: The new weekly brief
 subtitle: The Swift Weekly Brief gets a new home
-redirect_from: /new-weekly-brief/
 ---
 
 In case you are [late to the party](https://twitter.com/jesse_squires/status/687457899992383488), I finally found some time to give the *Swift Weekly Brief* a proper home. Starting this newsletter kind of happened by accident when I [first wrote](/swift-open-source/) about the Swift open source announcement. Since then, it was kind of bootstrapped here on my personal blog and started to feel awkward. I hacked together [the new site](http://swiftweekly.github.io) in a couple of nights and moved all the previous posts over. Today's [issue #5](http://swiftweekly.github.io/issue-5/) is the first one to be originally published at [swiftweekly.github.io](http://swiftweekly.github.io). However, there is more here than just organization and a nice separation of concerns.

--- a/_posts/2016-02-06-jsqmessages-call-for-contributors.md
+++ b/_posts/2016-02-06-jsqmessages-call-for-contributors.md
@@ -2,7 +2,6 @@
 layout: post
 title: Call for contributors
 subtitle: Join the JSQMessagesViewController team!
-redirect_from: /jsqmessages-call-for-contributors/
 ---
 
 Do you love writing code? Are you passionate about open source? Do you want to get more involved, but have yet to find a project to which you want contribute? Are you interested in contributing to a widely used, impactful project? Then I have a proposition for you! 😄 I am looking for dedicated core contributors to help maintain [JSQMessagesViewController](https://github.com/jessesquires/JSQMessagesViewController)!

--- a/_posts/2016-02-19-swifty-presenters.md
+++ b/_posts/2016-02-19-swifty-presenters.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swifty view controller presenters
 subtitle: Talk at Realm in San Francisco
-redirect_from: /swifty-presenters/
 ---
 
 A few weeks ago, I spoke at [Realm](https://realm.io) in San Francisco at the Swift Language User Group ([#SLUG](https://www.meetup.com/swift-language/events/227833264/)) meetup. A [video of the talk](https://realm.io/news/slug-jesse-squires-swifty-view-controller-presenters/) is now online over at Realm's blog, where it is synced with my [slides](https://speakerdeck.com/jessesquires/swifty-view-controller-presenters). If you haven’t already seen it, go check it out!

--- a/_posts/2016-03-21-contributing-to-swift.md
+++ b/_posts/2016-03-21-contributing-to-swift.md
@@ -2,7 +2,6 @@
 layout: post
 title: Contributing to open source Swift
 subtitle: Talk at try! Swift conference in Tokyo
-redirect_from: /contributing-to-swift/
 ---
 
 Earlier this month I had the incredible opportunity to speak at the [try! Swift conference](http://www.tryswiftconf.com/en) in Tokyo, Japan. 🇯🇵 It was such a fun and rewarding experience. A [video of the talk](https://realm.io/news/tryswift-jesse-squires-contributing-open-source-swift/) is now online over at [Realm's](https://realm.io) blog, where it is synced with my [slides](https://speakerdeck.com/jessesquires/contributing-to-open-source-swift). If you have not already seen it, go check it out!

--- a/_posts/2016-05-20-swift-documentation.md
+++ b/_posts/2016-05-20-swift-documentation.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swift documentation
 subtitle: Writing, generating, and publishing great docs in Swift
-redirect_from: /swift-documentation/
 ---
 
 The Swift community is ecstatic about Swift. There are so many new libraries being released each week that some have created [package indexes](https://swiftmodules.com) &mdash; even [IBM](https://developer.ibm.com/swift/products/package-catalog/). But of course, a library is only as great as its documentation.

--- a/_posts/2016-05-22-open-source-everything.md
+++ b/_posts/2016-05-22-open-source-everything.md
@@ -2,7 +2,6 @@
 layout: post
 title: Open source everything
 subtitle: Getting meaningful contributions to move your projects forward
-redirect_from: /open-source-everything/
 ---
 
 I recently had an incredible experience with one of my open source projects that I'd like to share. It's a story of openness and collaboration that I hope other open source project maintainers will find valuable. This post continues the theme of "building successful open source projects" from my [previous article](/swift-documentation/) on documentation.

--- a/_posts/2016-06-04-avoiding-objc-in-swift.md
+++ b/_posts/2016-06-04-avoiding-objc-in-swift.md
@@ -2,7 +2,6 @@
 layout: post
 title: Avoiding the overuse of @objc in Swift
 subtitle: Don't let Objective-C cramp your style
-redirect_from: /avoiding-objc-in-swift/
 ---
 
 A few days ago I was (finally!) updating a project to use Swift 2.2 and I ran into a few issues when converting to use the new `#selector` syntax introduced by proposal [SE-0022](https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md). If using `#selector` from within a protocol extension, that protocol must be declared as `@objc`. The former `Selector("method:")` syntax did not have this requirement.

--- a/_posts/2016-06-14-the-a5-is-dead.md
+++ b/_posts/2016-06-14-the-a5-is-dead.md
@@ -2,7 +2,6 @@
 layout: post
 title: The A5 is dead (almost)
 subtitle: iOS 10 drops support for A5 devices
-redirect_from: /the-a5-is-dead/
 ---
 
 As developers, we've been [lamenting](http://arstechnica.com/apple/2015/09/ios-9-on-the-ipad-2-not-worse-than-ios-8-but-missing-many-features/) the continued existence of the inferior [A5 system-on-a-chip](https://en.wikipedia.org/wiki/Apple_A5) for the past couple of years. Both [iOS 8](https://en.wikipedia.org/wiki/IOS_8) and [iOS 9](https://en.wikipedia.org/wiki/IOS_9) continued to support *iPhone 4S, iPad 2, and iPad Mini 1* &mdash; devices that struggled to run the OS itself. I had hoped that iOS 9 would finally drop support for these less powerful devices, but it didn't. Today, we can finally [say goodbye](http://arstechnica.com/apple/2016/06/goodbye-a5-ios-10-ends-support-for-iphone-4s-ipad-2-and-more/) to the A5. Well, almost.

--- a/_posts/2016-07-03-swift-3-sherlocked-my-libraries.md
+++ b/_posts/2016-07-03-swift-3-sherlocked-my-libraries.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swift 3 sherlocked my library
 subtitle: Many of our "Swifty" wrappers are no longer necessary
-redirect_from: /swift-3-sherlocked-my-libraries/
 ---
 
 What's my favorite thing about Swift 3? Not maintaining third-party libraries that make Cocoa more "Swifty".

--- a/_posts/2016-07-25-migrating-to-swift-3.md
+++ b/_posts/2016-07-25-migrating-to-swift-3.md
@@ -2,7 +2,6 @@
 layout: post
 title: Migrating to Swift 3
 subtitle: Advice, tips, and warnings
-redirect_from: /migrating-to-swift-3/
 ---
 
 I spent most of my free time last weekend and a few days of last week on migrating my Swift code to Swift 3.0 &mdash; I migrated my open source projects as well as my private side projects. Overall, I would say my experience was "OK". It definitely could have been better, but I think the largest problem was overcoming the cognitive hurdle of seeing all the changes and errors from Xcode's migration tool at once. The best thing to do is wipe away the tears, put your headphones on, and start hacking. 🤓

--- a/_posts/2016-07-31-enums-as-configs.md
+++ b/_posts/2016-07-31-enums-as-configs.md
@@ -2,7 +2,6 @@
 layout: post
 title: "Enums as configuration&#58; the anti-pattern"
 subtitle: Implementing the open/closed principle
-redirect_from: /enums-as-configs/
 ---
 
 One of the most common patterns I see in software design with Objective-C (and sometimes Swift), is the use of enumeration types (`enum`) as configurations for a class. For example, passing an `enum` to a `UIView` to style it in a certain way. In this article, I explain why I think this is an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and provide a more robust, modular, and extensible approach to solving this problem.

--- a/_posts/2016-09-30-speaking-at-frenchkit.md
+++ b/_posts/2016-09-30-speaking-at-frenchkit.md
@@ -2,7 +2,6 @@
 layout: post
 title: Speaking at FrenchKit
 subtitle: Paris, France
-redirect_from: /speaking-at-frenchkit/
 ---
 
 Last week I attended and [gave a talk](https://speakerdeck.com/jessesquires/140-proposals-in-30-minutes) at [FrenchKit](http://frenchkit.fr) in Paris, France. As expected, it was an amazing conference &mdash; especially considering it was the first FrenchKit ever. I think the organizers are already thinking about FrenchKit 2017, so keep an eye out and definitely go if you can. I know I will.

--- a/_posts/2016-10-01-shipping-swift-3.md
+++ b/_posts/2016-10-01-shipping-swift-3.md
@@ -2,7 +2,6 @@
 layout: post
 title: Shipping Swift 3.0
 subtitle: An update on my open source libraries
-redirect_from: /shipping-swift-3/
 ---
 
 I'm happy to share that all of my open source Swift libraries have (finally) been updated for Swift 3. If you've been waiting for any of these final releases, you can now run `pod update` or `carthage update` and relax &mdash; sorry it took so long! I wrote about [migrating to Swift 3](/migrating-to-swift-3/) a few months ago and this post shares the final results of the process that I outlined in there.

--- a/_posts/2016-10-03-understanding-swift-evolution.md
+++ b/_posts/2016-10-03-understanding-swift-evolution.md
@@ -2,7 +2,6 @@
 layout: post
 title: Understanding Swift Evolution
 subtitle: What can we learn by analyzing the proposals?
-redirect_from: /understanding-swift-evolution/
 ---
 
 I recently [spoke at the FrenchKit conference](/speaking-at-frenchkit/) about [Swift Evolution](https://github.com/apple/swift-evolution). The [talk](https://speakerdeck.com/jessesquires/140-proposals-in-30-minutes), *140 proposals in 30 minutes*, was originally intended to be an overview of the process and each of the proposals. However, as I was writing the talk, it evolved into something much more interesting. I ended up writing some code to analyze the proposals instead.

--- a/_posts/2016-10-06-contributing-to-swift-weekly.md
+++ b/_posts/2016-10-06-contributing-to-swift-weekly.md
@@ -2,7 +2,6 @@
 layout: post
 title: Contributing to Swift Weekly Brief
 subtitle: Join us as a guest writer
-redirect_from: /contributing-to-swift-weekly/
 ---
 
 You may have noticed that I did not write [the](http://swiftweekly.github.io/issue-38/) [last](http://swiftweekly.github.io/issue-39/) [few](http://swiftweekly.github.io/issue-40/) issues of the [*Swift Weekly Brief*](http://swiftweekly.github.io). I took some much needed time off, and I was able to unplug and relax thanks to the wonderful [JP Simard](https://twitter.com/simjp) and [Brian Gesiak](https://twitter.com/modocache). They took over for those weeks and I can't thank them enough! [Bas Broek](https://twitter.com/BasThomas) also made regular contributions, which was super helpful.

--- a/_posts/2016-11-05-140-proposals-frenchkit-video.md
+++ b/_posts/2016-11-05-140-proposals-frenchkit-video.md
@@ -2,7 +2,6 @@
 layout: post
 title: 140 proposals in 30 minutes
 subtitle: Talk at FrenchKit conference in Paris
-redirect_from: /140-proposals-frenchkit-video/
 ---
 
 As you may know, I [spoke at FrenchKit](/speaking-at-frenchkit/) a couple of months ago. The organizers have been working hard to get all of [the videos](http://frenchkit.fr/#videos) edited and uploaded, and my talk is [now available here](https://www.youtube.com/watch?v=0sYQAtoK3VQ). 😄

--- a/_posts/2017-01-08-swift-documentation-part-2.md
+++ b/_posts/2017-01-08-swift-documentation-part-2.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swift documentation, Part 2
 subtitle: Generating and publishing docs in Swift
-redirect_from: /swift-documentation-part-2/
 ---
 
 I previously wrote about [writing great documentation in Swift](/swift-documentation/). If you haven't read that post, head there now to catch up. This post is a follow-up with updates for GitHub's new way [to publish docs](https://github.com/blog/2228-simpler-github-pages-publishing). This is how I've setup all of my Swift open source projects.

--- a/_posts/2017-01-16-testing-without-ocmock.md
+++ b/_posts/2017-01-16-testing-without-ocmock.md
@@ -2,7 +2,6 @@
 layout: post
 title: Testing and mocking without OCMock
 subtitle: For Swift and Objective-C
-redirect_from: /testing-without-ocmock/
 ---
 
 [OCMock](http://ocmock.org) is a powerful [mock object](https://en.wikipedia.org/wiki/Mock_object) unit testing library for Objective-C. Even if you are using Swift, as long as your classes inherit from `NSObject`, you can use [some of its features](http://ocmock.org/swift/). But what if you are writing pure Swift code which does not have access to the dynamic Objective-C runtime? Or, what if you don't want your Swift code to be [hampered](/avoiding-objc-in-swift/) by `NSObject` subclasses and `@objc` annotations? Perhaps, you merely want to avoid dependencies and use 'plain old' `XCTest` with Objective-C. It's relatively easy and lightweight to achieve the same effect in some testing scenarios *without* using `OCMock`.

--- a/_posts/2017-01-23-pushing-limits-of-pop.md
+++ b/_posts/2017-01-23-pushing-limits-of-pop.md
@@ -2,7 +2,6 @@
 layout: post
 title: Pushing the limits of protocol-oriented programming
 subtitle: Talk at Swift Summit in San Francisco
-redirect_from: /pushing-limits-of-pop/
 ---
 
 A few months ago, I spoke at [Swift Summit](https://swiftsummit.com) in San Francisco. The conference has a reputation for providing high-quality talks, and this year was no different. Fortunately, I was able to see nearly all of the talks and not a single one disappointed me. It was such a great conference. The [video and full transcript](https://www.skilled.io/u/swiftsummit/pushing-the-limits-of-protocol-oriented-programming) of my talk are now available. The videos of the other talks will be coming online over the next few weeks. I would recommend watching all of them!

--- a/_posts/2017-02-08-prioritization.md
+++ b/_posts/2017-02-08-prioritization.md
@@ -2,7 +2,6 @@
 layout: post
 title: Prioritization
 subtitle: Or how I learned to stop worrying and love being a normal human
-redirect_from: /prioritization/
 ---
 
 Let me [list](https://medium.com/@thejameskyle/dear-javascript-7e14ffcae36c#.4kno1s8mc) the [ways](https://medium.com/@azerbike/i-ve-just-liberated-my-modules-9045c06be67c#.o23m0vlx3) that [burnout](http://chris.eidhof.nl/post/burnout/) [happens](https://medium.com/@oleg008/fighting-burnout-with-open-source-ba87559ad844#.b4u5csdav) in this [industry](https://medium.com/@jedwatson/sustainable-open-source-ff29c42a54c5#.5i277t9vl), and [especially](https://medium.com/the-javascript-collection/healthy-open-source-967fa8be7951#.9w8myd6u4) in [open source](https://medium.com/@fox/the-dark-side-of-open-source-ba5a66c8a4c3#.g76f3syvn). No, I don't need to. Because [you know them already](http://www.stilldrinking.com/programming-sucks). I'm not burnt out, I promise. I'm reprioritizing, just letting you know.

--- a/_posts/2017-02-09-sleazy-recruiting.md
+++ b/_posts/2017-02-09-sleazy-recruiting.md
@@ -2,7 +2,6 @@
 layout: post
 title: Sleazy recruiting
 subtitle: LAMP stack for an iOS developer
-redirect_from: /sleazy-recruiting/
 ---
 
 Today I found out that I'm part of a [class action lawsuit](http://www.courthousenews.com/2015/10/07/class-of-users-irked-by-talentbin-dossiers.htm) against a service that I never signed up for called [*TalentBin*](https://www.crunchbase.com/organization/talentbin#/entity). As you have likely experienced, most recruiting in the tech industry is debase, disingenuous, boilerplate garbage. But this &mdash; this is definitely a new a low.

--- a/_posts/2017-02-10-refactoring-singletons-in-swift.md
+++ b/_posts/2017-02-10-refactoring-singletons-in-swift.md
@@ -2,7 +2,6 @@
 layout: post
 title: Refactoring singleton usage in Swift
 subtitle: Tips for a cleaner, modular, and testable codebase
-redirect_from: /refactoring-singletons-in-swift/
 ---
 
 In software development, [singletons](https://en.wikipedia.org/wiki/Singleton_pattern) are widely [discouraged](https://www.objc.io/issues/13-architecture/singletons/) and [frowned upon](http://coliveira.net/software/day-19-avoid-singletons/) &mdash; but with good reason. They are difficult or impossible to test, and they entangle your codebase when used implicitly in other classes, making code reuse difficult. Most of the time, a singleton amounts to nothing more than a disguise for global, mutable state. Everyone knows at least knows *that* is a terrible idea. However, singletons are occasionally an unavoidable and necessary evil. How can we incorporate them into our code in a clean, modular, and testable way?

--- a/_posts/2017-02-15-adapting-to-change-and-cutting-corners.md
+++ b/_posts/2017-02-15-adapting-to-change-and-cutting-corners.md
@@ -2,7 +2,6 @@
 layout: post
 title: Adapting to change
 subtitle: And cutting corners
-redirect_from: /adapting-to-change-and-cutting-corners/
 ---
 
 In my [previous post](/refactoring-singletons-in-swift/) I mentioned writing *adaptive* code. That is to say, writing code that is easy to change, code that is malleable. It's like creating [adaptive user interfaces](/adaptive-user-interfaces/) but for all of your classes, modules, and other components.

--- a/_posts/2017-03-07-swift-unwrapped.md
+++ b/_posts/2017-03-07-swift-unwrapped.md
@@ -2,7 +2,6 @@
 layout: post
 title: Swift Unwrapped
 subtitle: Co-hosting a new podcast with JP Simard
-redirect_from: /swift-unwrapped/
 ---
 
 A few months back, [JP Simard](https://twitter.com/simjp) and I decided to start a podcast about [Swift](https://swift.org) &mdash; the language itself, its evolution and development, the Swift.org open source projects, and general Swifty news. There are a ton of great podcasts out there about developing for Apple platforms and Apple news, but there's nothing exclusively about Swift the language. In many ways, this podcast is an extension of and commentary on the [*Swift Weekly Brief*](https://swiftweekly.github.io) newsletter. However, we'll be doing deep dives on various topics and elaborating on concepts in greater detail. I'm excited to share that we launched [Swift Unwrapped](https://spec.fm/podcasts/swift-unwrapped) yesterday with [Spec.fm](https://twitter.com/specfm)!

--- a/_posts/2017-04-05-thoughts-on-swift-access-control.md
+++ b/_posts/2017-04-05-thoughts-on-swift-access-control.md
@@ -2,7 +2,6 @@
 layout: post
 title: Thoughts on Swift access control
 subtitle: And the opportunity costs of Swift evolution
-redirect_from: /thoughts-on-swift-access-control/
 ---
 
 There has been a ton of debate on the [swift-evolution mailing lists](https://lists.swift.org/mailman/listinfo/swift-evolution) about [access control](https://twitter.com/swiftlybrief/status/846938309666492417) in Swift. A couple of days ago, the proposal [SE-0159](https://github.com/apple/swift-evolution/blob/master/proposals/0159-fix-private-access-levels.md): *Fix Private Access Levels* was [rejected](https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000337.html). I want to share my thoughts on this, as well as thoughts on the larger story for access control in general. But first, let's begin with a brief history of access control in Swift.

--- a/_posts/2017-05-28-a-fair-hotel.md
+++ b/_posts/2017-05-28-a-fair-hotel.md
@@ -2,7 +2,6 @@
 layout: post
 title: A Fair Hotel
 subtitle: Choosing a place to stay for your next conference
-redirect_from: /a-fair-hotel/
 ---
 
 Earlier this week, the [Tech Workers Coalition](https://techworkerscoalition.org) and [UNITE HERE!](http://unitehere.org) in San Francisco hosted a [panel discussion](https://www.meetup.com/Tech-Workers-Coalition/events/240112005/) on how we can use our power as consumers to support hotel workers in the Bay Area and across the United States. The tech industry is full of remote workers, as well as conference organizers that host thousands of conferences each year &mdash; meaning thousands of programmers, designers, product managers, and others **travel all the time** to attend these conferences or attend their own company's events. By choosing to stay at [a fair hotel](http://www.fairhotel.org), you can make a significant impact on an industry where workers are struggling to negotiate fair wages and benefits.


### PR DESCRIPTION
- map 301 redirects in htaccess
- remove `redirect_from:` for old posts
- update config
- format config

closes #55