### PR TITLE
Update 2023-07-18-navigation-link-accessory-view-swiftui.md

### DIFF
--- a/_posts/2023-07-18-navigation-link-accessory-view-swiftui.md
+++ b/_posts/2023-07-18-navigation-link-accessory-view-swiftui.md
@@ -37,13 +37,13 @@ This allows you to provide an entirely custom `View` for the `NavigationLink`. I
 
 ```swift
 struct BetterNavigationLink<Label: View, Destination: View>: View {
-    let label: () -> Label
-    let destination: () -> Destination
+    let label: Label
+    let destination: Destination
 
-    init(@ViewBuilder label: @escaping () -> Label,
-         @ViewBuilder destination: @escaping () -> Destination) {
-        self.label = label
-        self.destination = destination
+    init(@ViewBuilder label: () -> Label,
+         @ViewBuilder destination: () -> Destination) {
+        self.label = label()
+        self.destination = destination()
     }
 
     var body: some View {
@@ -51,13 +51,13 @@ struct BetterNavigationLink<Label: View, Destination: View>: View {
         // Hides default chevron accessory view for NavigationLink
         ZStack {
             NavigationLink {
-                self.destination()
+                self.destination
             } label: {
                 EmptyView()
             }
             .opacity(0)
 
-            self.label()
+            self.label
         }
     }
 }


### PR DESCRIPTION
Fixed BetterNavigationLink so the 2 View closures are resolved at init.

FYI:

Q: But, what’s the recommended way to use a @ViewBuilder for custom components: calling it right away in the init() and storing the view, or calling it later inside the body and storing the view builder itself? A: We’d generally recommend resolving it right away and storing the view https://onmyway133.com/posts/wwdc-swiftui-lounge/#use-viewbuillder

*Have you read the [Contributing Guidelines](https://github.com/jessesquires/.github/blob/master/CONTRIBUTING.md)?*

Issue #

## Describe your changes

*Clearly and concisely describe what's in this pull request. Include screenshots, if necessary.*
